### PR TITLE
curl-cffi 0.11.4 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:                    # [win]
+  - vs2022                     # [win]
+cxx_compiler:                  # [win]
+  - vs2022                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,10 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_impersonate" %}
 {% set tests_to_skip = tests_to_skip + " or test_impersonate_edge" %}
 {% set tests_to_skip = tests_to_skip + " or test_impersonate_safari" %}
+# Unlikely to work across all platforms (even failed on linux-aarch64)
+# -- rate limiting?
+{% set tests_to_skip = tests_to_skip + " or test_relative_redirect_n" %}
+
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - cffi >=1.12.0
+    - cffi 1.17.1  # oldest py313
   run:
     - python
     - cffi >=1.12.0
@@ -30,22 +30,9 @@ requirements:
   run_constrained:
     - markdownify >=1.1.0
 
-# RuntimeError: cannot release un-acquired lock
-{% set tests_to_ignore = "--ignore tests/threads/test_gevent.py" %}
-# ModuleNotFoundError: No module named 'proxy'
-{% set tests_to_ignore = tests_to_ignore + " --ignore tests/unittest" %}
-# fixture 'fn' not found
-{% set tests_to_ignore = tests_to_ignore + " --ignore tests/threads/test_eventlet.py" %}
-# ModuleNotFoundError: No module named 'proxy'
-{% set tests_to_skip = "unittest" %}
-# Several impersonation hashes incorrect?  The first is Chrome
-{% set tests_to_skip = tests_to_skip + " or test_impersonate" %}
-{% set tests_to_skip = tests_to_skip + " or test_impersonate_edge" %}
-{% set tests_to_skip = tests_to_skip + " or test_impersonate_safari" %}
-# Unlikely to work across all platforms (even failed on linux-aarch64)
-# -- rate limiting?
-{% set tests_to_skip = tests_to_skip + " or test_relative_redirect_n" %}
-
+# XXX skipped tests where the unittests require proxy and the rest are
+# probing external hosts (often httpbin.org) which won't work for all
+# platforms.
 
 test:
   source_files:
@@ -62,13 +49,8 @@ test:
     - curl_cffi.utils
   requires:
     - pip
-    - pytest    # [py<313]
-    - eventlet  # [py<313]
-    - gevent    # [py<313]
   commands:
     - pip check
-    # We don't have gevent (and greenlet for py313)
-    - pytest -v tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [py<313]
 
 about:
   home: https://github.com/lexiforest/curl_cffi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,36 +12,73 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [not linux]
+  skip: true  # [py<39]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - {{ stdlib('c') }}
   host:
     - python
-    - wheel
-    - setuptools
-    - cffi >=1.12.0
     - pip
+    - setuptools
+    - wheel
+    - cffi >=1.12.0
   run:
     - python
     - cffi >=1.12.0
     - certifi >=2024.2.2
+  run_constrained:
+    - markdownify >=1.1.0
+
+# RuntimeError: cannot release un-acquired lock
+{% set tests_to_ignore = "--ignore tests/threads/test_gevent.py" %}
+# ModuleNotFoundError: No module named 'proxy'
+{% set tests_to_ignore = tests_to_ignore + " --ignore tests/unittest" %}
+# fixture 'fn' not found
+{% set tests_to_ignore = tests_to_ignore + " --ignore tests/threads/test_eventlet.py" %}
+# ModuleNotFoundError: No module named 'proxy'
+{% set tests_to_skip = "unittest" %}
+# Several impersonation hashes incorrect?  The first is Chrome
+{% set tests_to_skip = tests_to_skip + " or test_impersonate" %}
+{% set tests_to_skip = tests_to_skip + " or test_impersonate_edge" %}
+{% set tests_to_skip = tests_to_skip + " or test_impersonate_safari" %}
 
 test:
+  source_files:
+    - tests
   imports:
     - curl_cffi
-  commands:
-    - pip check
+    - curl_cffi.const
+    - curl_cffi.requests
+    - curl_cffi.requests.cookies
+    - curl_cffi.requests.errors
+    - curl_cffi.requests.exceptions
+    - curl_cffi.requests.models
+    - curl_cffi.requests.utils
+    - curl_cffi.utils
   requires:
     - pip
+    - pytest    # [py<313]
+    - eventlet  # [py<313]
+    - gevent    # [py<313]
+  commands:
+    - pip check
+    # We don't have gevent (and greenlet for py313)
+    - pytest -v tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})"  # [py<313]
 
 about:
   home: https://github.com/lexiforest/curl_cffi
   summary: libcurl ffi bindings for Python, with impersonation support.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  description: |
+    Unlike other pure Python http clients like httpx or requests,
+    curl_cffi can impersonate browsers’ TLS signatures or JA3
+    fingerprints. If you are blocked by some website for no obvious
+    reason, you can give this package a try.
+  doc_url: https://curl-cffi.readthedocs.io
+  dev_url: https://github.com/lexiforest/curl_cffi
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
curl-cffi 0.11.4 

**Destination channel:** Defaults

### Links

- [PKG-8505]
- dev_url:        https://github.com/lexiforest/curl_cffi/tree/v0.11.4
- conda_forge:    https://github.com/conda-forge/curl-cffi-feedstock
- pypi:           https://pypi.org/project/curl-cffi/0.11.4
- pypi inspector: https://inspector.pypi.io/project/curl-cffi/0.11.4

### Explanation of changes:

- new fork of conda-forge
- ignoring `skip # [not linux]`
- tests for `py313` require `gevent`, `greenlet` and possibly `eventlet` so skipped
- actually, skip all the tests, `unittests` require `proxy` (which we don't have) and the rest are probing external hosts (which worn't work for all platforms)


[PKG-8505]: https://anaconda.atlassian.net/browse/PKG-8505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ